### PR TITLE
修复 r68s dts 编译时 PCIE 的地址 warning

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-fastrhino-r68s.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-fastrhino-r68s.dts
@@ -510,7 +510,7 @@
 	lane-map = <0 1>;
 	status = "okay";
 
-	pcie@10 {
+	pcie@0,0 {
 		reg = <0x00100000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
@@ -530,7 +530,7 @@
 	lane-map = <1 0>;
 	status = "okay";
 
-	pcie@20 {
+	pcie@0,0 {
 		reg = <0x00200000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;


### PR DESCRIPTION
照 compiler 的建议改了，测了一下好像不影响 PCIE 工作

<img width="1108" alt="图片" src="https://user-images.githubusercontent.com/4849177/182764233-361b916c-3780-4caf-b63d-912beee9ec40.png">

<img width="626" alt="图片" src="https://user-images.githubusercontent.com/4849177/182764488-c2ad468d-49a7-49eb-89cd-9e5147cb2884.png">

[搜到的讨论](https://patchwork.kernel.org/project/linux-arm-kernel/patch/20210830103909.323356-1-nsaenzju@redhat.com/#24415303)