### PR TITLE
修复 regulator 名称造成的 cpufreq 异常

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-fastrhino-r68s.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-fastrhino-r68s.dts
@@ -204,13 +204,12 @@
 	status = "okay";
 
 	vdd_cpu: regulator@1c {
-		compatible = "tcs,tcs452x";
+		compatible = "tcs,tcs4525";
 		reg = <0x1c>;
 		vin-supply = <&vcc5v0_sys>;
-		regulator-compatible = "fan53555-reg";
 		regulator-name = "vdd_cpu";
-		regulator-min-microvolt = <712500>;
-		regulator-max-microvolt = <1390000>;
+		regulator-min-microvolt = <800000>;
+		regulator-max-microvolt = <1150000>;
 		regulator-ramp-delay = <2300>;
 		fcs,suspend-voltage-selector = <1>;
 		regulator-boot-on;


### PR DESCRIPTION
可能 fan53555 修改过接口，`tcs,tcs452x` 现在驱动不认了，对照 [i2c_device_id](https://github.com/unifreq/linux-5.18.y/blob/main/drivers/regulator/fan53555.c#L653) 做了修改

cpufreq-dt 在 probe 的时候会依赖 CPU 的 regulator，dev_pm_opp_set_regulators 失败的话会弹出流程，造成网页上和 banner 无法显示 CPU 频率（以及无法自动拉高频率的性能问题？）

fan53555 依赖的内核驱动选项在内核配置仓库那边的 [issue](https://github.com/unifreq/arm64-kernel-configs/issues/3#issuecomment-1206541107) 更新了

参考 [rock 3a 的配置](https://github.com/unifreq/linux-5.18.y/blob/main/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts#L263) 收窄了电压范围